### PR TITLE
Fix unrecognized base64 function in deploy workflow

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -34,9 +34,11 @@ jobs:
         run: tsc --skipLibCheck --resolveJsonModule --esModuleInterop --outDir build -t es5 Simulator/rabbitConsumer.ts
         
       - name: Setup SSH
-        uses: webfactory/ssh-agent@v0.8.0
-        with:
-          ssh-private-key: ${{ secrets.SSH_PRIVATE_KEY_BASE64 }}
+        run: |
+          echo "${{ secrets.SSH_PRIVATE_KEY_BASE64 }}" | base64 -d > /tmp/ssh_key
+          chmod 600 /tmp/ssh_key
+          eval $(ssh-agent -s)
+          ssh-add /tmp/ssh_key
           
       - name: Add known hosts
         run: |
@@ -54,3 +56,8 @@ jobs:
       - name: Reload PM2 process
         run: |
           ssh ${{ secrets.DEPLOY_USER }}@${{ secrets.DEPLOY_HOST }} "PATH=$PATH:/root/.nvm/versions/node/v18.12.1/bin && cd ${{ secrets.DEPLOY_PATH }} && pm2 reload rabbitConsumer"
+          
+      - name: Cleanup
+        if: always()
+        run: |
+          rm -f /tmp/ssh_key


### PR DESCRIPTION
Fixes "Unrecognized function: 'base64'" error by manually decoding the SSH private key and adding cleanup.

The `base64()` function is not natively supported in GitHub Actions expressions. This PR replaces the `webfactory/ssh-agent` action with a manual setup that decodes the base64-encoded SSH private key using `base64 -d` and adds a cleanup step to remove the temporary key file.

---
[Slack Thread](https://elihaidvgmail-imz5498.slack.com/archives/D099W2J1DHR/p1755182143099649?thread_ts=1755182143.099649&cid=D099W2J1DHR)

<a href="https://cursor.com/background-agent?bcId=bc-2bb2744a-b187-43da-882e-b9700492f7f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-2bb2744a-b187-43da-882e-b9700492f7f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

